### PR TITLE
TASK-3: Use Docker Compose to Start Compiler Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,34 @@ git clone https://github.com/butterman0423/mpide-platform.git
 cd /path/to/mpide-platform
 ```
 
-Follow the instructions in `./src/mpide-frontend/README.md` and `./src/compiler/README.md` to run both the frontend and compiler microservices. Ensure both are running correctly before proceeding.
+In a seperate terminal instance, start the frontend server.
+```
+cd /path/to/mpide-platform
+cd src/mpide-frontend
+npm install
+npm run dev
+```
 
-Install dependencies, compile the project, and execute the backend service.
+Then, in another terminal, spin up the compiler service.
+```
+cd /path/to/mpide-platform
+docker compose up
+```
+
+Lastly, install dependencies, compile the project, and execute the backend service.
 ```
 ./mvnw clean install compile
 java -jar target/mpide-platform
 ```
 
 *For `Windows` OS, replace `./mvnw` with `./mvnw.cmd`.*
+
+## Stopping the Compiler Service
+
+To spin down the service, run:
+```
+docker compose down
+```
 
 # Code Style and Formatting
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,1 +1,4 @@
-services: {}
+services:
+  compiler:
+    build: ./src/compiler
+

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-docker-compose</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/src/compiler/README.md
+++ b/src/compiler/README.md
@@ -2,17 +2,26 @@
 
 Compiles scripts sent-in and returns their binary executables for the Online Microprocessor IDE.
 
-# Installation
+# Quick Start
+
+This project is better ran via Docker. Ensure that this is installed 
+```
+cd path/to/mpide-compiler
+docker build --tag mpide-compiler .
+docker run mpide-compiler
+```
+
+Alternatively, this service can be ran via Docker Compose in the root working directory of the repository.
+```
+docker compose up
+```
+More information about this in the uppermost `README.md` file.
+
+# Development
 
 This project uses [Python](https://www.python.org/) version 3.12 (or later). Make sure to install this version installed on your local system.
 
 Additionally, this project is built using [uv](https://docs.astral.sh/uv/guides/install-python/) as its package manager. This guide will use this program for its installation and execution steps. However, other tools such as `.venv` or `conda` can be used as well (but there will be no guide to setup this service here).
-
---- TODO ---
-Since this is built and shipped as a Docker containerized service, wait for [STORY-COMP-1](https://github.com/butterman0423/mpide-platform/issues/9) to be completed first.
-
-
-# Code Style and Formatting
 
 To ensure that all contributions has the same code format, run the linter before pushing and creating your PR.
 ```


### PR DESCRIPTION
Close #23.

Let's the compiler service be built and executed via `docker compose up`, and spin down via `docker compose down`.
